### PR TITLE
Init simdjson to version 3.10.1

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -3,6 +3,8 @@ cmake -B build/ ^
     -D SIMDJSON_DEVELOPER_MODE=OFF ^
     -D SIMDJSON_BUILD_STATIC_LIB=ON ^
     -D BUILD_SHARED_LIBS=ON ^
+    -D CMAKE_BUILD_TYPE=Release ^
+    -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
     %CMAKE_ARGS%
 if errorlevel 1 exit 1
 

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -7,6 +7,7 @@ cmake -B build/ \
     -D SIMDJSON_DEVELOPER_MODE=OFF \
     -D SIMDJSON_BUILD_STATIC_LIB=ON \
     -D BUILD_SHARED_LIBS=ON \
+    -D CMAKE_BUILD_TYPE=Release \
     ${CMAKE_ARGS}
 
 cmake --build build/ --parallel "${CPU_COUNT}" --verbose

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -88,6 +88,7 @@ outputs:
 about:
   home: https://simdjson.org/
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
   summary: Parsing gigabytes of JSON per second
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -59,7 +59,7 @@ outputs:
         - if not exist %LIBRARY_LIB%\cmake\simdjson\simdjson-config.cmake (exit 1)  # [win]
         # Running a test trying to link to the library
         - cmake -G Ninja -S test/ -B build/ -D TEST_TARGET=simdjson ${CMAKE_ARGS}  # [unix]
-        - cmake -G Ninja -S test/ -B build/ -D TEST_TARGET=simdjson %CMAKE_ARGS%   # [win]
+        - cmake -G Ninja -S test/ -B build/ -D TEST_TARGET=simdjson -DCMAKE_BUILD_TYPE=Release %CMAKE_ARGS%   # [win]
         - cmake --build build/
         - cmake --build build --target test
 
@@ -81,7 +81,7 @@ outputs:
       commands:
         # Running a test trying to link to the library
         - cmake -G Ninja -S test/ -B build/ -D TEST_TARGET=simdjson_static ${CMAKE_ARGS}  # [unix]
-        - cmake -G Ninja -S test/ -B build/ -D TEST_TARGET=simdjson_static %CMAKE_ARGS%   # [win]
+        - cmake -G Ninja -S test/ -B build/ -D TEST_TARGET=simdjson_static -DCMAKE_BUILD_TYPE=Release %CMAKE_ARGS%   # [win]
         - cmake --build build/
         - cmake --build build --target test
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "3.10.1" %}
-{% set sha256 = "1e8f881cb2c0f626c56cd3665832f1e97b9d4ffc648ad9e1067c134862bba060" %}
 
 # For dispatching between Unix and Windows
 {% set install_prefix = "." %}  # [unix]
@@ -14,7 +13,7 @@ package:
 
 source:
   url: https://github.com/simdjson/simdjson/archive/v{{ version }}.tar.gz
-  sha256: "{{ sha256 }}"
+  sha256: 1e8f881cb2c0f626c56cd3665832f1e97b9d4ffc648ad9e1067c134862bba060
 
 build:
   number: 0
@@ -22,7 +21,6 @@ build:
 requirements:
   build:
     - {{ compiler('cxx') }}
-    - {{ stdlib("c") }}
     - cmake
     - ninja
 
@@ -42,7 +40,6 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - {{ stdlib("c") }}
         - cmake
         - ninja
     test:


### PR DESCRIPTION
simdjson 3.10.1

**Destination channel:** {defaults}

### Links

- [PKG-6219](https://anaconda.atlassian.net/browse/PKG-6219) 
- [Upstream repository](https://github.com/simdjson/simdjson/)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - [`simdjson 3.10.1`](https://github.com/AnacondaRecipes/simdjson-feedstock/pull/1/)
  - [`libsolv 0.7.30`](https://github.com/AnacondaRecipes/libsolv-feedstock/pull/5)
  - [`cpp-expected 1.1.0`](https://github.com/AnacondaRecipes/cpp-expected-feedstock/pull/2)
  - [`mamba 2.0.4`](https://github.com/AnacondaRecipes/mamba-feedstock/pull/19)

### Explanation of changes:

- ...


[PKG-6219]: https://anaconda.atlassian.net/browse/PKG-6219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ